### PR TITLE
Add ModLens and Seedance director workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ After that, when a new task comes up, it checks this list and decides whether th
 
 - **[dexhunter/seedance2-skill](https://github.com/dexhunter/seedance2-skill)** — Creates structured prompts for Seedance 2.0 video generation.
 
+- **[Emily2040/seedance-2.0](https://github.com/Emily2040/seedance-2.0)** — A modular director workflow for Seedance 2.0, covering storyboards, camera movement, lighting, performance, sound, multi-shot continuity, platform adaptation, and systematic failure diagnosis.
+
 - **[ningzimu/xiaohu-video-translate](https://github.com/ningzimu/xiaohu-video-translate)** — Turns foreign-language videos into Chinese-subtitled videos locally through downloading, transcription, translation, polishing, and subtitle burn-in.
 
 - **[MapleShaw/yt-dlp-downloader-skill](https://github.com/MapleShaw/yt-dlp-downloader-skill)** — Downloads videos through an agent workflow built around `yt-dlp`.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ After that, when a new task comes up, it checks this list and decides whether th
 - [Automation & Productivity](#automation--productivity)
 - [Obsidian](#obsidian)
 - [Writing & Publishing](#writing--publishing)
+- [Multimodal & Vision](#multimodal--vision)
 - [Image & Visual Design](#image--visual-design)
 - [Video & Motion](#video--motion)
 - [Presentations](#presentations)
@@ -105,6 +106,10 @@ After that, when a new task comes up, it checks this list and decides whether th
 - **[leeguooooo/Mailbox](https://github.com/leeguooooo/Mailbox)** — Provides CLI-first email management with multi-account support, local sync, and interfaces for agents.
 
 - **[op7418/Claude-to-IM-skill](https://github.com/op7418/Claude-to-IM-skill)** — Bridges coding agents to Telegram, Discord, and Feishu/Lark for remote conversations.
+
+## Multimodal & Vision
+
+- **[liustack/modlens](https://github.com/liustack/modlens)** — Adds image understanding to text-only coding agents through pluggable vision providers, supporting pasted images, local files, and image URLs with structured OCR, layout, semantics, and uncertainty output.
 
 ## Image & Visual Design
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,6 +22,7 @@
 - [自动化与效率](#自动化与效率)
 - [Obsidian](#obsidian)
 - [写作与发布](#写作与发布)
+- [多模态与视觉理解](#多模态与视觉理解)
 - [图像与视觉设计](#图像与视觉设计)
 - [视频与动态内容](#视频与动态内容)
 - [PPT 与演示文稿](#ppt-与演示文稿)
@@ -105,6 +106,10 @@
 - **[leeguooooo/Mailbox](https://github.com/leeguooooo/Mailbox)** — 提供 CLI 优先的多账号邮件管理、本地同步和 Agent 调用接口。
 
 - **[op7418/Claude-to-IM-skill](https://github.com/op7418/Claude-to-IM-skill)** — 将编码 Agent 连接到 Telegram、Discord 和飞书，支持远程对话。
+
+## 多模态与视觉理解
+
+- **[liustack/modlens](https://github.com/liustack/modlens)** — 通过可插拔的视觉模型为纯文本编码 Agent 补充图片理解能力，支持粘贴图片、本地文件和图片 URL，并输出结构化的 OCR、版面、语义及不确定项。
 
 ## 图像与视觉设计
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -145,6 +145,8 @@
 
 - **[dexhunter/seedance2-skill](https://github.com/dexhunter/seedance2-skill)** — 为 Seedance 2.0 视频生成创建结构化提示词。
 
+- **[Emily2040/seedance-2.0](https://github.com/Emily2040/seedance-2.0)** — 一套面向 Seedance 2.0 的模块化导演工作流，覆盖分镜、运镜、灯光、表演、声音、多镜头连续性、平台适配及系统化失败诊断。
+
 - **[ningzimu/xiaohu-video-translate](https://github.com/ningzimu/xiaohu-video-translate)** — 在本地完成下载、转写、翻译、润色和字幕烧录，将外语视频制作为中文字幕视频。
 
 - **[MapleShaw/yt-dlp-downloader-skill](https://github.com/MapleShaw/yt-dlp-downloader-skill)** — 通过基于 `yt-dlp` 的 Agent 工作流下载视频。


### PR DESCRIPTION
## What changed

- Added a new **Multimodal & Vision / 多模态与视觉理解** category.
- Added `liustack/modlens` with concise English and Chinese descriptions.
- Added `Emily2040/seedance-2.0` under **Video & Motion / 视频与动态内容**.
- Kept the new Seedance entry beside the existing lightweight `dexhunter/seedance2-skill` so readers can distinguish a structured prompt skill from a full director workflow.

## Why

ModLens adds structured image understanding to text-only coding agents. The Seedance repository provides a broader modular video-directing workflow spanning storyboards, camera movement, lighting, performance, sound, continuity, platform adaptation, and failure diagnosis.

## Validation

- Verified both README files on the branch.
- Verified navigation anchors, section placement, repository links, and bilingual descriptions.
- Confirmed both Seedance entries remain present and describe different scopes.