### PR TITLE
Add mattpocock software engineering workflow skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ After that, when a new task comes up, it checks this list and decides whether th
 
 - **[tanweai/pua](https://github.com/tanweai/pua)** — A high-agency coding workflow that combines persistence prompts, systematic debugging, and proactive execution.
 
+### Software Engineering Workflows
+
+- **[mattpocock/skills](https://github.com/mattpocock/skills)** — A composable software-engineering workflow collection covering requirements clarification, specifications and ticket breakdown, TDD implementation, systematic debugging, parallel code review, architecture improvement, research, and cross-session handoffs.
+
 ### Frontend & UI
 
 - **[Vercel Web Design Guidelines](https://github.com/vercel-labs/agent-skills/tree/main/skills/web-design-guidelines)** — Reviews web UI against current interface guidelines, including accessibility and UX best practices.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -45,6 +45,10 @@
 
 - **[tanweai/pua](https://github.com/tanweai/pua)** — 结合持续推进提示、系统化调试和主动执行的高能动性编码工作流。
 
+### 软件工程工作流
+
+- **[mattpocock/skills](https://github.com/mattpocock/skills)** — 一套可组合的软件工程工作流 Skills，覆盖需求澄清、规格与任务拆解、TDD 实现、系统化调试、并行代码审查、架构优化、技术调研及跨会话交接。
+
 ### 前端与 UI
 
 - **[Vercel Web Design Guidelines](https://github.com/vercel-labs/agent-skills/tree/main/skills/web-design-guidelines)** — 按最新界面规范审查网页 UI，覆盖可访问性和 UX 最佳实践。


### PR DESCRIPTION
## What changed

- Add a dedicated Software Engineering Workflows subsection under Coding & Development
- Add `mattpocock/skills` with concise English and Chinese descriptions
- Keep `README.md` and `README.zh-CN.md` synchronized

## Why

The repository provides a substantial, composable Agent Skills workflow spanning requirements clarification, specification and ticket breakdown, TDD, debugging, parallel review, architecture improvement, research, and handoffs.

## Validation

- Confirmed both README files contain the new entry
- Compared the branch against `main`: only the two README files changed