### PR TITLE
Add Qwen MM Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ After that, when a new task comes up, it checks this list and decides whether th
 
 - **[liustack/modlens](https://github.com/liustack/modlens)** — Adds image understanding to text-only coding agents through pluggable vision providers, supporting pasted images, local files, and image URLs with structured OCR, layout, semantics, and uncertainty output.
 
+- **[QwenLM/Qwen-MM-Plugins](https://github.com/QwenLM/Qwen-MM-Plugins)** — Official multimodal Agent Skills and MCP servers for Qwen models, covering image, video, document, and 3D understanding, OCR, grounding, long-video memory, native audio-video analysis, media generation and editing, Blender, FreeCAD, and educational explainer workflows.
+
 ## Image & Visual Design
 
 - **[ningzimu/handdrawn-tech-illustrations](https://github.com/ningzimu/handdrawn-tech-illustrations)** — Generates Chinese hand-drawn technical illustrations for articles, explanations, and social covers.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -117,6 +117,8 @@
 
 - **[liustack/modlens](https://github.com/liustack/modlens)** — 通过可插拔的视觉模型为纯文本编码 Agent 补充图片理解能力，支持粘贴图片、本地文件和图片 URL，并输出结构化的 OCR、版面、语义及不确定项。
 
+- **[QwenLM/Qwen-MM-Plugins](https://github.com/QwenLM/Qwen-MM-Plugins)** — Qwen 官方多模态 Agent Skills 与 MCP Servers，覆盖图片、视频、文档和 3D 理解，以及 OCR、目标定位、长视频记忆、原生音视频分析、媒体生成与编辑、Blender、FreeCAD 和讲题视频工作流。
+
 ## 图像与视觉设计
 
 - **[ningzimu/handdrawn-tech-illustrations](https://github.com/ningzimu/handdrawn-tech-illustrations)** — 为文章、概念解释和社交媒体封面生成中文手绘技术配图。


### PR DESCRIPTION
## What changed

- Added `QwenLM/Qwen-MM-Plugins` to the Multimodal & Vision section.
- Updated both the English and Simplified Chinese README files.
- Described its official Qwen multimodal Agent Skills and MCP capabilities.

## Why

The project is a strong, official multimodal Agent Skill collection that complements the existing ModLens entry with broader image, video, document, audio, 3D, editing, and generation workflows.

## Validation

- Confirmed the entry appears exactly once in each README.
- Confirmed both entries are located in the intended multimodal section.